### PR TITLE
More lintian overrides for hockeypuck-dump.

### DIFF
--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -4,6 +4,9 @@ hockeypuck binary: unstripped-binary-or-object usr/bin/hockeypuck-load
 hockeypuck binary: hardening-no-relro usr/bin/hockeypuck-load
 hockeypuck binary: unstripped-binary-or-object usr/bin/hockeypuck-pbuild
 hockeypuck binary: hardening-no-relro usr/bin/hockeypuck-pbuild
+hockeypuck binary: unstripped-binary-or-object usr/bin/hockeypuck-dump
+hockeypuck binary: hardening-no-relro usr/bin/hockeypuck-dump
 # hockeypuck: binary-without-manpage usr/bin/hockeypuck
 # hockeypuck: binary-without-manpage usr/bin/hockeypuck-load
 # hockeypuck: binary-without-manpage usr/bin/hockeypuck-pbuild
+# hockeypuck: binary-without-manpage usr/bin/hockeypuck-dump


### PR DESCRIPTION
Would be nice to generate manpages for the binaries to address those
warnings.
