### PR TITLE
prepare.bash: New godeps source repo location

### DIFF
--- a/prepare.bash
+++ b/prepare.bash
@@ -10,7 +10,7 @@ export BUILD_PACKAGE=github.com/hockeypuck/server
 ### Set up GOPATH
 
 export GOPATH=$(pwd)
-for pkg in launchpad.net/godeps github.com/mitchellh/gox; do
+for pkg in github.com/rogpeppe/godeps github.com/mitchellh/gox; do
 	go get ${pkg}
 	go install ${pkg}
 done


### PR DESCRIPTION
godeps sources seem to have moved to GitHub.

Quoting https://launchpad.net/godeps :
> This package has now officially moved to github.com/rogpeppe/godeps.
> 
> This repository will not be updated further except if a security-related
> bug is found.